### PR TITLE
Add new MCP Server: Aave-MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,9 +312,6 @@ We have provided a list of available servers below, along with their respective 
 - <img src="https://github.com/Bankless.png?size=120" width="12px" height="12px" /> **[Bankless Onchain MCP Server
 ](catalog/Bankless/onchain-mcp/onchain-mcp/README.md)** - MCP (Model Context Protocol) server for blockchain data interaction through the Bankless API.
 
-- <img src="https://github.com/Bankless.png?size=120" width="12px" height="12px" /> **[Bankless Onchain MCP Server
-](catalog/Bankless/onchain-mcp/onchain-mcp/README.md)** - MCP (Model Context Protocol) server for blockchain data interaction through the Bankless API.
-
 - <img src="https://github.com/bart6114.png?size=120" width="12px" height="12px" /> **[Bear MCP Server
 ](catalog/bart6114/my-bear-mcp-server/my-bear-mcp-server/README.md)** - A Model Context Protocol (MCP) server that allows AI assistants like Claude to read notes from the [Bear](https://bear.app/) note-taking app. This implementation connects directly to the Bear SQLite database in a read-only mode, ensuring your notes remain safe and unmodified.
 
@@ -1274,6 +1271,15 @@ We have provided a list of available servers below, along with their respective 
 
 - <img src="https://github.com/tomekkorbak.png?size=120" width="12px" height="12px" /> **[Oura MCP Server
 ](catalog/tomekkorbak/oura-mcp-server/oura-mcp-server/README.md)** - A [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) server that provides access to the Oura API. It allows language models to query sleep, readiness, and resilience data from Oura API.
+
+- <img src="https://github.com/Too-Far.png?size=120" width="12px" height="12px" /> **[Aave MCP Server
+](catalog/Too-Far/aave-mcp/aave-mcp/README.md)** - A containerized version of "Aave MCP Server"
+
+- <img src="https://github.com/Too-Far.png?size=120" width="12px" height="12px" /> **[Aave MCP Server
+](catalog/Too-Far/aave-mcp/bin/README.md)** - A containerized version of "Aave MCP Server"
+
+- <img src="https://github.com/Too-Far.png?size=120" width="12px" height="12px" /> **[Aave MCP Server
+](catalog/Too-Far/aave-mcp/src/README.md)** - A containerized version of "Aave MCP Server"
 
 - <img src="https://github.com/translated.png?size=120" width="12px" height="12px" /> **[Lara Translate MCP Server
 ](catalog/translated/lara-mcp/lara-mcp/README.md)** - A Model Context Protocol (MCP) Server for [Lara Translate](https://laratranslate.com/translate) API, enabling powerful translation capabilities with support for language detection and context-aware translations.

--- a/catalog/Too-Far/aave-mcp/aave-mcp/README.md
+++ b/catalog/Too-Far/aave-mcp/aave-mcp/README.md
@@ -1,0 +1,93 @@
+
+# Aave MCP Server
+
+A containerized version of "Aave MCP Server"
+
+> Repository: [Too-Far/aave-mcp](https://github.com/Too-Far/aave-mcp)
+
+## Description
+
+A containerized version of "Aave MCP Server"
+
+
+## Usage
+
+The containers are built automatically and are available on the GitHub Container Registry.
+
+1. Pull the Docker image:
+
+```bash
+docker pull ghcr.io/metorial/mcp-container--too-far--aave-mcp--aave-mcp
+```
+
+2. Run the container:
+
+```bash
+docker run -i --rm \ 
+-e ETHEREUM_RPC_URL=ethereum-rpc-url -e ARBITRUM_RPC_URL=arbitrum-rpc-url -e OPTIMISM_RPC_URL=optimism-rpc-url -e POLYGON_RPC_URL=polygon-rpc-url -e AVALANCHE_RPC_URL=avalanche-rpc-url -e BASE_RPC_URL=base-rpc-url \
+ghcr.io/metorial/mcp-container--too-far--aave-mcp--aave-mcp  "yarn run start"
+```
+
+- `--rm` removes the container after it exits, so you don't have to clean up manually.
+- `-i` allows you to interact with the container in your terminal.
+
+
+
+### Configuration
+
+The container supports the following configuration options:
+
+
+
+
+#### Environment Variables
+
+- `ETHEREUM_RPC_URL`
+- `ARBITRUM_RPC_URL`
+- `OPTIMISM_RPC_URL`
+- `POLYGON_RPC_URL`
+- `AVALANCHE_RPC_URL`
+- `BASE_RPC_URL`
+
+
+
+
+## Usage with Claude
+
+```json
+{
+  "mcpServers": {
+    "aave-mcp": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "ghcr.io/metorial/mcp-container--too-far--aave-mcp--aave-mcp",
+        "yarn run start"
+      ],
+      "env": {
+        "ETHEREUM_RPC_URL": "ethereum-rpc-url",
+        "ARBITRUM_RPC_URL": "arbitrum-rpc-url",
+        "OPTIMISM_RPC_URL": "optimism-rpc-url",
+        "POLYGON_RPC_URL": "polygon-rpc-url",
+        "AVALANCHE_RPC_URL": "avalanche-rpc-url",
+        "BASE_RPC_URL": "base-rpc-url"
+      }
+    }
+  }
+}
+```
+
+# License
+
+Please refer to the license provided in [the project repository](https://github.com/Too-Far/aave-mcp) for more information.
+
+## Contributing
+
+Contributions are welcome! If you notice any issues or have suggestions for improvements, please open an issue or submit a pull request.
+
+<div align="center">
+  <sub>Containerized with ❤️ by <a href="https://metorial.com">Metorial</a></sub>
+</div>
+  

--- a/catalog/Too-Far/aave-mcp/aave-mcp/manifest.json
+++ b/catalog/Too-Far/aave-mcp/aave-mcp/manifest.json
@@ -1,0 +1,103 @@
+{
+  "id": "aave-mcp",
+  "fullId": "Too-Far/aave-mcp/aave-mcp",
+  "repo": {
+    "provider": "github.com",
+    "owner": "Too-Far",
+    "repo": "aave-mcp",
+    "branch": "main",
+    "url": "https://github.com/Too-Far/aave-mcp"
+  },
+  "config": {
+    "argumentsTemplate": null,
+    "configValues": [
+      {
+        "title": "tsconfig.json",
+        "description": null,
+        "default": null,
+        "required": true,
+        "fields": [
+          {
+            "type": "file",
+            "key": "tsconfig.json"
+          }
+        ]
+      },
+      {
+        "title": "ethereum-rpc-url",
+        "description": null,
+        "default": null,
+        "required": false,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "ETHEREUM_RPC_URL"
+          }
+        ]
+      },
+      {
+        "title": "arbitrum-rpc-url",
+        "description": null,
+        "default": null,
+        "required": false,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "ARBITRUM_RPC_URL"
+          }
+        ]
+      },
+      {
+        "title": "optimism-rpc-url",
+        "description": null,
+        "default": null,
+        "required": false,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "OPTIMISM_RPC_URL"
+          }
+        ]
+      },
+      {
+        "title": "polygon-rpc-url",
+        "description": null,
+        "default": null,
+        "required": false,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "POLYGON_RPC_URL"
+          }
+        ]
+      },
+      {
+        "title": "avalanche-rpc-url",
+        "description": null,
+        "default": null,
+        "required": false,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "AVALANCHE_RPC_URL"
+          }
+        ]
+      },
+      {
+        "title": "base-rpc-url",
+        "description": null,
+        "default": null,
+        "required": false,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "BASE_RPC_URL"
+          }
+        ]
+      }
+    ]
+  },
+  "subdirectory": "/",
+  "title": "Aave MCP Server",
+  "description": "A containerized version of \"Aave MCP Server\""
+}

--- a/catalog/Too-Far/aave-mcp/aave-mcp/versions/b6c05049b04f1116c595196bcda3b7f3a4b7c759/version.json
+++ b/catalog/Too-Far/aave-mcp/aave-mcp/versions/b6c05049b04f1116c595196bcda3b7f3a4b7c759/version.json
@@ -1,0 +1,165 @@
+{
+  "serverId": "Too-Far/aave-mcp/aave-mcp",
+  "version": "b6c05049b04f1116c595196bcda3b7f3a4b7c759",
+  "manifest": {
+    "id": "aave-mcp",
+    "fullId": "Too-Far/aave-mcp/aave-mcp",
+    "repo": {
+      "provider": "github.com",
+      "owner": "Too-Far",
+      "repo": "aave-mcp",
+      "branch": "main",
+      "url": "https://github.com/Too-Far/aave-mcp"
+    },
+    "config": {
+      "argumentsTemplate": null,
+      "configValues": [
+        {
+          "title": "tsconfig.json",
+          "description": null,
+          "default": null,
+          "required": true,
+          "fields": [
+            {
+              "type": "file",
+              "key": "tsconfig.json"
+            }
+          ]
+        },
+        {
+          "title": "ethereum-rpc-url",
+          "description": null,
+          "default": null,
+          "required": false,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "ETHEREUM_RPC_URL"
+            }
+          ]
+        },
+        {
+          "title": "arbitrum-rpc-url",
+          "description": null,
+          "default": null,
+          "required": false,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "ARBITRUM_RPC_URL"
+            }
+          ]
+        },
+        {
+          "title": "optimism-rpc-url",
+          "description": null,
+          "default": null,
+          "required": false,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "OPTIMISM_RPC_URL"
+            }
+          ]
+        },
+        {
+          "title": "polygon-rpc-url",
+          "description": null,
+          "default": null,
+          "required": false,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "POLYGON_RPC_URL"
+            }
+          ]
+        },
+        {
+          "title": "avalanche-rpc-url",
+          "description": null,
+          "default": null,
+          "required": false,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "AVALANCHE_RPC_URL"
+            }
+          ]
+        },
+        {
+          "title": "base-rpc-url",
+          "description": null,
+          "default": null,
+          "required": false,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "BASE_RPC_URL"
+            }
+          ]
+        }
+      ]
+    },
+    "subdirectory": "/",
+    "title": "Aave MCP Server",
+    "description": "A containerized version of \"Aave MCP Server\""
+  },
+  "manifestHash": "3e3e2a5764df1e3fc644698edfeebdbf",
+  "createdAt": "2025-05-13T19:44:02.177Z",
+  "builder": [
+    {
+      "type": "nixpacks",
+      "plan": {
+        "providers": [],
+        "buildImage": "ghcr.io/railwayapp/nixpacks:ubuntu-1745885067",
+        "variables": {
+          "CI": "true",
+          "NIXPACKS_METADATA": "node",
+          "NODE_ENV": "production",
+          "NPM_CONFIG_PRODUCTION": "false"
+        },
+        "phases": {
+          "build": {
+            "dependsOn": [
+              "install"
+            ],
+            "cmds": [
+              "yarn run build"
+            ],
+            "cacheDirectories": [
+              "node_modules/.cache"
+            ]
+          },
+          "install": {
+            "dependsOn": [
+              "setup"
+            ],
+            "cmds": [
+              "npm install -g corepack@0.24.1 && corepack enable",
+              "yarn install --frozen-lockfile"
+            ],
+            "cacheDirectories": [
+              "/usr/local/share/.cache/yarn/v6"
+            ],
+            "paths": [
+              "/app/node_modules/.bin"
+            ]
+          },
+          "setup": {
+            "nixPkgs": [
+              "nodejs_22",
+              "yarn-1_x"
+            ],
+            "nixOverlays": [
+              "https://github.com/railwayapp/nix-npm-overlay/archive/main.tar.gz"
+            ],
+            "nixpkgsArchive": "ffeebf0acf3ae8b29f8c7049cd911b9636efd7e7"
+          }
+        },
+        "start": {
+          "cmd": "yarn run start"
+        }
+      }
+    }
+  ]
+}

--- a/catalog/Too-Far/aave-mcp/bin/README.md
+++ b/catalog/Too-Far/aave-mcp/bin/README.md
@@ -1,0 +1,92 @@
+
+# Aave MCP Server
+
+A containerized version of "Aave MCP Server"
+
+> Repository: [Too-Far/aave-mcp](https://github.com/Too-Far/aave-mcp)
+
+## Description
+
+A containerized version of "Aave MCP Server"
+
+
+## Usage
+
+The containers are built automatically and are available on the GitHub Container Registry.
+
+1. Pull the Docker image:
+
+```bash
+docker pull ghcr.io/metorial/mcp-container--too-far--aave-mcp--bin
+```
+
+2. Run the container:
+
+```bash
+docker run -i --rm \ 
+-e ETHEREUM_RPC_URL=ethereum-rpc-url -e ARBITRUM_RPC_URL=arbitrum-rpc-url -e OPTIMISM_RPC_URL=optimism-rpc-url -e POLYGON_RPC_URL=polygon-rpc-url -e AVALANCHE_RPC_URL=avalanche-rpc-url -e BASE_RPC_URL=base-rpc-url \
+ghcr.io/metorial/mcp-container--too-far--aave-mcp--bin  
+```
+
+- `--rm` removes the container after it exits, so you don't have to clean up manually.
+- `-i` allows you to interact with the container in your terminal.
+
+
+
+### Configuration
+
+The container supports the following configuration options:
+
+
+
+
+#### Environment Variables
+
+- `ETHEREUM_RPC_URL`
+- `ARBITRUM_RPC_URL`
+- `OPTIMISM_RPC_URL`
+- `POLYGON_RPC_URL`
+- `AVALANCHE_RPC_URL`
+- `BASE_RPC_URL`
+
+
+
+
+## Usage with Claude
+
+```json
+{
+  "mcpServers": {
+    "bin": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "ghcr.io/metorial/mcp-container--too-far--aave-mcp--bin"
+      ],
+      "env": {
+        "ETHEREUM_RPC_URL": "ethereum-rpc-url",
+        "ARBITRUM_RPC_URL": "arbitrum-rpc-url",
+        "OPTIMISM_RPC_URL": "optimism-rpc-url",
+        "POLYGON_RPC_URL": "polygon-rpc-url",
+        "AVALANCHE_RPC_URL": "avalanche-rpc-url",
+        "BASE_RPC_URL": "base-rpc-url"
+      }
+    }
+  }
+}
+```
+
+# License
+
+Please refer to the license provided in [the project repository](https://github.com/Too-Far/aave-mcp) for more information.
+
+## Contributing
+
+Contributions are welcome! If you notice any issues or have suggestions for improvements, please open an issue or submit a pull request.
+
+<div align="center">
+  <sub>Containerized with ❤️ by <a href="https://metorial.com">Metorial</a></sub>
+</div>
+  

--- a/catalog/Too-Far/aave-mcp/bin/manifest.json
+++ b/catalog/Too-Far/aave-mcp/bin/manifest.json
@@ -1,0 +1,91 @@
+{
+  "id": "bin",
+  "fullId": "Too-Far/aave-mcp/bin",
+  "repo": {
+    "provider": "github.com",
+    "owner": "Too-Far",
+    "repo": "aave-mcp",
+    "branch": "main",
+    "url": "https://github.com/Too-Far/aave-mcp"
+  },
+  "config": {
+    "argumentsTemplate": null,
+    "configValues": [
+      {
+        "title": "ethereum-rpc-url",
+        "description": null,
+        "default": null,
+        "required": false,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "ETHEREUM_RPC_URL"
+          }
+        ]
+      },
+      {
+        "title": "arbitrum-rpc-url",
+        "description": null,
+        "default": null,
+        "required": false,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "ARBITRUM_RPC_URL"
+          }
+        ]
+      },
+      {
+        "title": "optimism-rpc-url",
+        "description": null,
+        "default": null,
+        "required": false,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "OPTIMISM_RPC_URL"
+          }
+        ]
+      },
+      {
+        "title": "polygon-rpc-url",
+        "description": null,
+        "default": null,
+        "required": false,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "POLYGON_RPC_URL"
+          }
+        ]
+      },
+      {
+        "title": "avalanche-rpc-url",
+        "description": null,
+        "default": null,
+        "required": false,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "AVALANCHE_RPC_URL"
+          }
+        ]
+      },
+      {
+        "title": "base-rpc-url",
+        "description": null,
+        "default": null,
+        "required": false,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "BASE_RPC_URL"
+          }
+        ]
+      }
+    ]
+  },
+  "subdirectory": "/bin",
+  "title": "Aave MCP Server",
+  "description": "A containerized version of \"Aave MCP Server\""
+}

--- a/catalog/Too-Far/aave-mcp/bin/versions/d5eda94cfe43916d320884ac05a5d6ecc324745d/version.json
+++ b/catalog/Too-Far/aave-mcp/bin/versions/d5eda94cfe43916d320884ac05a5d6ecc324745d/version.json
@@ -1,0 +1,107 @@
+{
+  "serverId": "Too-Far/aave-mcp/bin",
+  "version": "d5eda94cfe43916d320884ac05a5d6ecc324745d",
+  "manifest": {
+    "id": "bin",
+    "fullId": "Too-Far/aave-mcp/bin",
+    "repo": {
+      "provider": "github.com",
+      "owner": "Too-Far",
+      "repo": "aave-mcp",
+      "branch": "main",
+      "url": "https://github.com/Too-Far/aave-mcp"
+    },
+    "config": {
+      "argumentsTemplate": null,
+      "configValues": [
+        {
+          "title": "ethereum-rpc-url",
+          "description": null,
+          "default": null,
+          "required": false,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "ETHEREUM_RPC_URL"
+            }
+          ]
+        },
+        {
+          "title": "arbitrum-rpc-url",
+          "description": null,
+          "default": null,
+          "required": false,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "ARBITRUM_RPC_URL"
+            }
+          ]
+        },
+        {
+          "title": "optimism-rpc-url",
+          "description": null,
+          "default": null,
+          "required": false,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "OPTIMISM_RPC_URL"
+            }
+          ]
+        },
+        {
+          "title": "polygon-rpc-url",
+          "description": null,
+          "default": null,
+          "required": false,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "POLYGON_RPC_URL"
+            }
+          ]
+        },
+        {
+          "title": "avalanche-rpc-url",
+          "description": null,
+          "default": null,
+          "required": false,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "AVALANCHE_RPC_URL"
+            }
+          ]
+        },
+        {
+          "title": "base-rpc-url",
+          "description": null,
+          "default": null,
+          "required": false,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "BASE_RPC_URL"
+            }
+          ]
+        }
+      ]
+    },
+    "subdirectory": "/bin",
+    "title": "Aave MCP Server",
+    "description": "A containerized version of \"Aave MCP Server\""
+  },
+  "manifestHash": "ffb567d2df231dd0d1381813eddd383b",
+  "createdAt": "2025-05-13T19:34:32.271Z",
+  "builder": [
+    {
+      "type": "nixpacks",
+      "plan": {
+        "providers": [],
+        "buildImage": "ghcr.io/railwayapp/nixpacks:ubuntu-1745885067",
+        "phases": {}
+      }
+    }
+  ]
+}

--- a/catalog/Too-Far/aave-mcp/src/README.md
+++ b/catalog/Too-Far/aave-mcp/src/README.md
@@ -1,0 +1,92 @@
+
+# Aave MCP Server
+
+A containerized version of "Aave MCP Server"
+
+> Repository: [Too-Far/aave-mcp](https://github.com/Too-Far/aave-mcp)
+
+## Description
+
+A containerized version of "Aave MCP Server"
+
+
+## Usage
+
+The containers are built automatically and are available on the GitHub Container Registry.
+
+1. Pull the Docker image:
+
+```bash
+docker pull ghcr.io/metorial/mcp-container--too-far--aave-mcp--src
+```
+
+2. Run the container:
+
+```bash
+docker run -i --rm \ 
+-e ETHEREUM_RPC_URL=ethereum-rpc-url -e ARBITRUM_RPC_URL=arbitrum-rpc-url -e OPTIMISM_RPC_URL=optimism-rpc-url -e POLYGON_RPC_URL=polygon-rpc-url -e AVALANCHE_RPC_URL=avalanche-rpc-url -e BASE_RPC_URL=base-rpc-url \
+ghcr.io/metorial/mcp-container--too-far--aave-mcp--src  
+```
+
+- `--rm` removes the container after it exits, so you don't have to clean up manually.
+- `-i` allows you to interact with the container in your terminal.
+
+
+
+### Configuration
+
+The container supports the following configuration options:
+
+
+
+
+#### Environment Variables
+
+- `ETHEREUM_RPC_URL`
+- `ARBITRUM_RPC_URL`
+- `OPTIMISM_RPC_URL`
+- `POLYGON_RPC_URL`
+- `AVALANCHE_RPC_URL`
+- `BASE_RPC_URL`
+
+
+
+
+## Usage with Claude
+
+```json
+{
+  "mcpServers": {
+    "src": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "ghcr.io/metorial/mcp-container--too-far--aave-mcp--src"
+      ],
+      "env": {
+        "ETHEREUM_RPC_URL": "ethereum-rpc-url",
+        "ARBITRUM_RPC_URL": "arbitrum-rpc-url",
+        "OPTIMISM_RPC_URL": "optimism-rpc-url",
+        "POLYGON_RPC_URL": "polygon-rpc-url",
+        "AVALANCHE_RPC_URL": "avalanche-rpc-url",
+        "BASE_RPC_URL": "base-rpc-url"
+      }
+    }
+  }
+}
+```
+
+# License
+
+Please refer to the license provided in [the project repository](https://github.com/Too-Far/aave-mcp) for more information.
+
+## Contributing
+
+Contributions are welcome! If you notice any issues or have suggestions for improvements, please open an issue or submit a pull request.
+
+<div align="center">
+  <sub>Containerized with ❤️ by <a href="https://metorial.com">Metorial</a></sub>
+</div>
+  

--- a/catalog/Too-Far/aave-mcp/src/manifest.json
+++ b/catalog/Too-Far/aave-mcp/src/manifest.json
@@ -1,0 +1,91 @@
+{
+  "id": "src",
+  "fullId": "Too-Far/aave-mcp/src",
+  "repo": {
+    "provider": "github.com",
+    "owner": "Too-Far",
+    "repo": "aave-mcp",
+    "branch": "main",
+    "url": "https://github.com/Too-Far/aave-mcp"
+  },
+  "config": {
+    "argumentsTemplate": null,
+    "configValues": [
+      {
+        "title": "ethereum-rpc-url",
+        "description": null,
+        "default": null,
+        "required": false,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "ETHEREUM_RPC_URL"
+          }
+        ]
+      },
+      {
+        "title": "arbitrum-rpc-url",
+        "description": null,
+        "default": null,
+        "required": false,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "ARBITRUM_RPC_URL"
+          }
+        ]
+      },
+      {
+        "title": "optimism-rpc-url",
+        "description": null,
+        "default": null,
+        "required": false,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "OPTIMISM_RPC_URL"
+          }
+        ]
+      },
+      {
+        "title": "polygon-rpc-url",
+        "description": null,
+        "default": null,
+        "required": false,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "POLYGON_RPC_URL"
+          }
+        ]
+      },
+      {
+        "title": "avalanche-rpc-url",
+        "description": null,
+        "default": null,
+        "required": false,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "AVALANCHE_RPC_URL"
+          }
+        ]
+      },
+      {
+        "title": "base-rpc-url",
+        "description": null,
+        "default": null,
+        "required": false,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "BASE_RPC_URL"
+          }
+        ]
+      }
+    ]
+  },
+  "subdirectory": "/src",
+  "title": "Aave MCP Server",
+  "description": "A containerized version of \"Aave MCP Server\""
+}

--- a/catalog/Too-Far/aave-mcp/src/versions/d5eda94cfe43916d320884ac05a5d6ecc324745d/version.json
+++ b/catalog/Too-Far/aave-mcp/src/versions/d5eda94cfe43916d320884ac05a5d6ecc324745d/version.json
@@ -1,0 +1,107 @@
+{
+  "serverId": "Too-Far/aave-mcp/src",
+  "version": "d5eda94cfe43916d320884ac05a5d6ecc324745d",
+  "manifest": {
+    "id": "src",
+    "fullId": "Too-Far/aave-mcp/src",
+    "repo": {
+      "provider": "github.com",
+      "owner": "Too-Far",
+      "repo": "aave-mcp",
+      "branch": "main",
+      "url": "https://github.com/Too-Far/aave-mcp"
+    },
+    "config": {
+      "argumentsTemplate": null,
+      "configValues": [
+        {
+          "title": "ethereum-rpc-url",
+          "description": null,
+          "default": null,
+          "required": false,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "ETHEREUM_RPC_URL"
+            }
+          ]
+        },
+        {
+          "title": "arbitrum-rpc-url",
+          "description": null,
+          "default": null,
+          "required": false,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "ARBITRUM_RPC_URL"
+            }
+          ]
+        },
+        {
+          "title": "optimism-rpc-url",
+          "description": null,
+          "default": null,
+          "required": false,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "OPTIMISM_RPC_URL"
+            }
+          ]
+        },
+        {
+          "title": "polygon-rpc-url",
+          "description": null,
+          "default": null,
+          "required": false,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "POLYGON_RPC_URL"
+            }
+          ]
+        },
+        {
+          "title": "avalanche-rpc-url",
+          "description": null,
+          "default": null,
+          "required": false,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "AVALANCHE_RPC_URL"
+            }
+          ]
+        },
+        {
+          "title": "base-rpc-url",
+          "description": null,
+          "default": null,
+          "required": false,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "BASE_RPC_URL"
+            }
+          ]
+        }
+      ]
+    },
+    "subdirectory": "/src",
+    "title": "Aave MCP Server",
+    "description": "A containerized version of \"Aave MCP Server\""
+  },
+  "manifestHash": "b0f66f09837e611fc8ed80343add65b0",
+  "createdAt": "2025-05-13T19:33:42.002Z",
+  "builder": [
+    {
+      "type": "nixpacks",
+      "plan": {
+        "providers": [],
+        "buildImage": "ghcr.io/railwayapp/nixpacks:ubuntu-1745885067",
+        "phases": {}
+      }
+    }
+  ]
+}

--- a/catalog/index.json
+++ b/catalog/index.json
@@ -270,12 +270,6 @@
     "repoUrl": "https://github.com/Bankless/onchain-mcp/"
   },
   {
-    "id": "onchain-mcp",
-    "owner": "Bankless",
-    "repo": "onchain-mcp",
-    "repoUrl": "https://github.com/Bankless/onchain-mcp/"
-  },
-  {
     "id": "my-bear-mcp-server",
     "owner": "bart6114",
     "repo": "my-bear-mcp-server",
@@ -2194,6 +2188,24 @@
     "owner": "tomekkorbak",
     "repo": "oura-mcp-server",
     "repoUrl": "https://github.com/tomekkorbak/oura-mcp-server"
+  },
+  {
+    "id": "aave-mcp",
+    "owner": "Too-Far",
+    "repo": "aave-mcp",
+    "repoUrl": "https://github.com/Too-Far/aave-mcp"
+  },
+  {
+    "id": "bin",
+    "owner": "Too-Far",
+    "repo": "aave-mcp",
+    "repoUrl": "https://github.com/Too-Far/aave-mcp"
+  },
+  {
+    "id": "src",
+    "owner": "Too-Far",
+    "repo": "aave-mcp",
+    "repoUrl": "https://github.com/Too-Far/aave-mcp"
   },
   {
     "id": "lara-mcp",


### PR DESCRIPTION
This PR adds an Aave MCP, which wraps the Aave SDK. Provides tools for querying aave markets and users.