### PR TITLE
Use exact config key matching to avoid silent misconfiguration

### DIFF
--- a/packages/manifest/src/config.ts
+++ b/packages/manifest/src/config.ts
@@ -16,27 +16,27 @@ export interface ConfigValueField {
 
 export let buildConfig = (d: {
   cliArguments:
-    | {
-        template: string;
-        keys: {
-          key: string;
-          required?: boolean;
-        }[];
-      }
-    | {
-        arguments: {
-          key: string;
-          required?: boolean;
-        }[];
-      }
-    | null;
+  | {
+    template: string;
+    keys: {
+      key: string;
+      required?: boolean;
+    }[];
+  }
+  | {
+    arguments: {
+      key: string;
+      required?: boolean;
+    }[];
+  }
+  | null;
   environmentVariables:
-    | {
-        key: string;
-        required?: boolean;
-        environmentVariable?: string;
-      }[]
-    | null;
+  | {
+    key: string;
+    required?: boolean;
+    environmentVariable?: string;
+  }[]
+  | null;
   files: string[];
 }) => {
   let configs = new Map<string, ConfigValue>();
@@ -60,26 +60,12 @@ export let buildConfig = (d: {
   let getConfigValue = (key: string, opts?: { required?: boolean }) => {
     let normalizedKey = Cases.toKebabCase(key);
 
-    for (let k of configs.keys()) {
-      if (k.includes(normalizedKey) || normalizedKey.includes(k)) {
-        normalizedKey = k;
-        break;
-      }
+    let configValue = configs.get(normalizedKey);
+    if (!configValue) {
+      throw new Error(`Unknown config key: ${key}`);
     }
 
-    let configValue = configs.get(normalizedKey);
-    if (configValue) return [normalizedKey, configValue] as const;
-
-    return [
-      normalizedKey,
-      {
-        title: normalizedKey,
-        description: null,
-        default: null,
-        required: !!opts?.required,
-        fields: []
-      } satisfies ConfigValue
-    ] as const;
+    return [normalizedKey, configValue] as const;
   };
 
   if (d.environmentVariables) {


### PR DESCRIPTION
This PR removes substring-based config key matching and switches to exact key lookup.

The current behavior allows similar keys (e.g. `api-key` and `api-key-secret`) to
silently override each other depending on iteration order, which can lead to
hard-to-debug misconfigurations.

This change keeps behavior strict and explicit. Unknown keys now fail loudly
instead of being guessed.

Happy to adjust or drop this if it doesn’t align with the intended UX.