### PR TITLE
feat(catalog): add PagerDuty official MCP server

### DIFF
--- a/DOCKER_SERVERS.md
+++ b/DOCKER_SERVERS.md
@@ -1028,6 +1028,9 @@ We have provided a list of available servers below, along with their respective 
 - <img src="https://github.com/PaddleHQ.png?size=120" width="12px" height="12px" /> **[Paddle MCP Server
 ](catalog/PaddleHQ/paddle-mcp-server/paddle-mcp-server/README.md)** - This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server that provides tools for interacting with the Paddle API.
 
+- <img src="https://github.com/PagerDuty.png?size=120" width="12px" height="12px" /> **[PagerDuty's official MCP Server
+](catalog/PagerDuty/pagerduty-mcp-server/pagerduty-mcp-server/README.md)** - PagerDuty's official local MCP server for managing incidents, services, schedules, and event orchestrations directly from your MCP-enabled client.
+
 - <img src="https://github.com/PostHog.png?size=120" width="12px" height="12px" /> **[PostHog MCP Server 📊
 ](catalog/PostHog/posthog-mcp/posthog-mcp/README.md)** - A Model Context Protocol (MCP) server for interacting with PostHog. Create annotations and manage projects directly through Claude Desktop!
 

--- a/catalog/PagerDuty/pagerduty-mcp-server/pagerduty-mcp-server/README.md
+++ b/catalog/PagerDuty/pagerduty-mcp-server/pagerduty-mcp-server/README.md
@@ -1,0 +1,85 @@
+
+# PagerDuty's official MCP Server
+
+A containerized version of "PagerDuty's official MCP Server"
+
+> Repository: [PagerDuty/pagerduty-mcp-server](https://github.com/PagerDuty/pagerduty-mcp-server)
+
+## Description
+
+PagerDuty's official local MCP server for managing incidents, services, schedules, and event orchestrations directly from your MCP-enabled client.
+
+
+## Usage
+
+The containers are built automatically and are available on the GitHub Container Registry.
+
+1. Pull the Docker image:
+
+```bash
+docker pull ghcr.io/metorial/mcp-container--pagerduty--pagerduty-mcp-server--pagerduty-mcp-server
+```
+
+2. Run the container:
+
+```bash
+docker run -i --rm \ 
+-e PAGERDUTY_USER_API_KEY=pagerduty-user-api-key -e PAGERDUTY_API_HOST=pagerduty-api-host \
+ghcr.io/metorial/mcp-container--pagerduty--pagerduty-mcp-server--pagerduty-mcp-server  "uv run pagerduty-mcp"
+```
+
+- `--rm` removes the container after it exits, so you don't have to clean up manually.
+- `-i` allows you to interact with the container in your terminal.
+
+
+
+### Configuration
+
+The container supports the following configuration options:
+
+
+
+
+#### Environment Variables
+
+- `PAGERDUTY_USER_API_KEY`
+- `PAGERDUTY_API_HOST`
+
+
+
+
+## Usage with Claude
+
+```json
+{
+  "mcpServers": {
+    "pagerduty-mcp-server": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "ghcr.io/metorial/mcp-container--pagerduty--pagerduty-mcp-server--pagerduty-mcp-server",
+        "uv run pagerduty-mcp"
+      ],
+      "env": {
+        "PAGERDUTY_USER_API_KEY": "pagerduty-user-api-key",
+        "PAGERDUTY_API_HOST": "pagerduty-api-host"
+      }
+    }
+  }
+}
+```
+
+# License
+
+Please refer to the license provided in [the project repository](https://github.com/PagerDuty/pagerduty-mcp-server) for more information.
+
+## Contributing
+
+Contributions are welcome! If you notice any issues or have suggestions for improvements, please open an issue or submit a pull request.
+
+<div align="center">
+  <sub>Containerized with ❤️ by <a href="https://metorial.com">Metorial</a></sub>
+</div>
+  

--- a/catalog/PagerDuty/pagerduty-mcp-server/pagerduty-mcp-server/manifest.json
+++ b/catalog/PagerDuty/pagerduty-mcp-server/pagerduty-mcp-server/manifest.json
@@ -1,0 +1,49 @@
+{
+  "id": "pagerduty-mcp-server",
+  "fullId": "PagerDuty/pagerduty-mcp-server/pagerduty-mcp-server",
+  "repo": {
+    "provider": "github.com",
+    "owner": "PagerDuty",
+    "repo": "pagerduty-mcp-server",
+    "branch": "main",
+    "url": "https://github.com/PagerDuty/pagerduty-mcp-server"
+  },
+  "config": {
+    "argumentsTemplate": null,
+    "configValues": [
+      {
+        "title": "pagerduty-user-api-key",
+        "description": null,
+        "default": null,
+        "required": true,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "PAGERDUTY_USER_API_KEY"
+          }
+        ]
+      },
+      {
+        "title": "pagerduty-api-host",
+        "description": null,
+        "default": "https://api.pagerduty.com",
+        "required": false,
+        "fields": [
+          {
+            "type": "environment",
+            "key": "PAGERDUTY_API_HOST"
+          }
+        ]
+      }
+    ]
+  },
+  "build": {
+    "pythonVersion": "3.12",
+    "nixPackages": ["uv"],
+    "installCommand": "uv sync --no-dev --frozen",
+    "startCommand": "uv run pagerduty-mcp"
+  },
+  "subdirectory": "/",
+  "title": "PagerDuty's official MCP Server",
+  "description": "PagerDuty's official local MCP server for managing incidents, services, schedules, and event orchestrations directly from your MCP-enabled client."
+}

--- a/catalog/PagerDuty/pagerduty-mcp-server/pagerduty-mcp-server/versions/d2d706e6a6d3818a4a5f1c5dda66efb7c2f16c80/version.json
+++ b/catalog/PagerDuty/pagerduty-mcp-server/pagerduty-mcp-server/versions/d2d706e6a6d3818a4a5f1c5dda66efb7c2f16c80/version.json
@@ -1,0 +1,112 @@
+{
+  "serverId": "PagerDuty/pagerduty-mcp-server/pagerduty-mcp-server",
+  "version": "d2d706e6a6d3818a4a5f1c5dda66efb7c2f16c80",
+  "manifest": {
+    "id": "pagerduty-mcp-server",
+    "fullId": "PagerDuty/pagerduty-mcp-server/pagerduty-mcp-server",
+    "repo": {
+      "provider": "github.com",
+      "owner": "PagerDuty",
+      "repo": "pagerduty-mcp-server",
+      "branch": "main",
+      "url": "https://github.com/PagerDuty/pagerduty-mcp-server"
+    },
+    "config": {
+      "argumentsTemplate": null,
+      "configValues": [
+        {
+          "title": "pagerduty-user-api-key",
+          "description": null,
+          "default": null,
+          "required": true,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "PAGERDUTY_USER_API_KEY"
+            }
+          ]
+        },
+        {
+          "title": "pagerduty-api-host",
+          "description": null,
+          "default": "https://api.pagerduty.com",
+          "required": false,
+          "fields": [
+            {
+              "type": "environment",
+              "key": "PAGERDUTY_API_HOST"
+            }
+          ]
+        }
+      ]
+    },
+    "subdirectory": "/",
+    "title": "PagerDuty's official MCP Server",
+    "description": "PagerDuty's official local MCP server for managing incidents, services, schedules, and event orchestrations directly from your MCP-enabled client.",
+    "build": {
+      "startCommand": "uv run pagerduty-mcp",
+      "installCommand": "uv sync --no-dev --frozen",
+      "pythonVersion": "3.12",
+      "nixPackages": [
+        "uv"
+      ]
+    }
+  },
+  "manifestHash": "371cb7f1d865df8cde196414a6399bee",
+  "createdAt": "2026-05-21T13:34:25.863Z",
+  "builder": [
+    {
+      "type": "nixpacks",
+      "plan": {
+        "providers": [],
+        "buildImage": "ghcr.io/railwayapp/nixpacks:ubuntu-1745885067",
+        "variables": {
+          "NIXPACKS_METADATA": "python,poetry",
+          "NIXPACKS_POETRY_VERSION": "1.3.1",
+          "NIXPACKS_UV_VERSION": "0.7.3",
+          "PIP_DEFAULT_TIMEOUT": "100",
+          "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+          "PIP_NO_CACHE_DIR": "1",
+          "PYTHONDONTWRITEBYTECODE": "1",
+          "PYTHONFAULTHANDLER": "1",
+          "PYTHONHASHSEED": "random",
+          "PYTHONUNBUFFERED": "1",
+          "UV_PROJECT_ENVIRONMENT": "/opt/venv"
+        },
+        "phases": {
+          "install": {
+            "dependsOn": [
+              "setup"
+            ],
+            "cmds": [
+              "uv sync --no-dev --frozen"
+            ],
+            "cacheDirectories": [
+              "/root/.cache/pip"
+            ],
+            "paths": [
+              "/opt/venv/bin"
+            ]
+          },
+          "setup": {
+            "nixPkgs": [
+              "uv",
+              "python313",
+              "gcc"
+            ],
+            "nixLibs": [
+              "zlib",
+              "stdenv.cc.cc.lib"
+            ],
+            "nixOverlays": [],
+            "nixpkgsArchive": "bc8f8d1be58e8c8383e683a06e1e1e57893fff87",
+            "aptPkgs": []
+          }
+        },
+        "start": {
+          "cmd": "uv run pagerduty-mcp"
+        }
+      }
+    }
+  ]
+}

--- a/catalog/index.json
+++ b/catalog/index.json
@@ -1692,6 +1692,12 @@
     "repoUrl": "https://github.com/PaddleHQ/paddle-mcp-server"
   },
   {
+    "id": "pagerduty-mcp-server",
+    "owner": "PagerDuty",
+    "repo": "pagerduty-mcp-server",
+    "repoUrl": "https://github.com/PagerDuty/pagerduty-mcp-server"
+  },
+  {
     "id": "posthog-mcp",
     "owner": "PostHog",
     "repo": "posthog-mcp",


### PR DESCRIPTION
PagerDuty is a widely used incident management tool and felt like a natural fit for the Metorial catalog. Adding the official MCP server maintained by PagerDuty themselves.

Had to sort out a couple of things. The repo uses uv for dependency management, not Poetry, and nixpacks was auto-detecting it as a Poetry project and failing. Added explicit install and start commands to the manifest to fix that. Also marked the API key as required and made the API host optional with the US endpoint as the default, so EU users can still override it.

Build passed locally and the container starts correctly.