### PR TITLE
Harden MCP server argument parsing

### DIFF
--- a/packages/server-config/src/parseMCPServers.test.ts
+++ b/packages/server-config/src/parseMCPServers.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test';
+import { parseMCPServers } from './parseMCPServers';
+
+let parse = (server: unknown) => parseMCPServers(JSON.stringify(server));
+
+describe('parseMCPServers', () => {
+  test('does not treat uvx installer option values as MCP server arguments', () => {
+    let result = parse({
+      mcpServers: {
+        linear: {
+          command: 'uvx',
+          args: [
+            '--from',
+            'git+https://github.com/example/linear-mcp',
+            'linear-mcp',
+            '--workspace',
+            'WORKSPACE_ID'
+          ],
+          env: {
+            LINEAR_API_KEY: '...'
+          }
+        }
+      }
+    });
+
+    expect(result?.cliArguments).toEqual({
+      template: '--workspace WORKSPACE_ID',
+      keys: [{ key: 'WORKSPACE_ID' }]
+    });
+    expect(result?.environmentVariables).toEqual([{ key: 'LINEAR_API_KEY' }]);
+  });
+
+  test('does not treat npx package option values as MCP server arguments', () => {
+    let result = parse({
+      mcpServers: {
+        github: {
+          command: 'npx',
+          args: [
+            '--package',
+            '@modelcontextprotocol/server-github',
+            'mcp-server-github',
+            '--repo',
+            'OWNER/REPO'
+          ],
+          env: {
+            GITHUB_PERSONAL_ACCESS_TOKEN: '...'
+          }
+        }
+      }
+    });
+
+    expect(result?.cliArguments).toEqual({
+      template: '--repo OWNER/REPO',
+      keys: []
+    });
+  });
+
+  test('parses arguments after uv run options and the server entrypoint', () => {
+    let result = parse({
+      mcpServers: {
+        docs: {
+          command: 'uv',
+          args: [
+            'run',
+            '--with',
+            'mcp-server-docs',
+            'mcp-server-docs',
+            '--api-key',
+            'DOCS_API_KEY'
+          ]
+        }
+      }
+    });
+
+    expect(result?.cliArguments).toEqual({
+      template: '--api-key DOCS_API_KEY',
+      keys: [{ key: 'DOCS_API_KEY' }]
+    });
+  });
+});

--- a/packages/server-config/src/parseMCPServers.ts
+++ b/packages/server-config/src/parseMCPServers.ts
@@ -26,7 +26,7 @@ export let parseMCPServers = (config: string) => {
     return {
       cliArguments: {
         template: args.join(' '),
-        keys: args.filter(a => a.toUpperCase() === a).map(key => ({ key }))
+        keys: args.filter(looksLikeConfigKey).map(key => ({ key }))
       },
       environmentVariables: Object.entries(server.env || {}).map(([key, value]) => ({
         key
@@ -40,25 +40,120 @@ export let parseMCPServers = (config: string) => {
 
 let pathCommand = (a: string) => (b: string) => a === b || b.endsWith(`/${a}`);
 
+let looksLikeConfigKey = (arg: string) => /^[A-Z][A-Z0-9_]*$/.test(arg);
+
+let optionTakesValue = (arg: string, valueOptions: Set<string>) => {
+  if (!arg.startsWith('-')) return false;
+  if (arg.includes('=')) return false;
+
+  return valueOptions.has(arg);
+};
+
+let argsAfterEntrypoint = (
+  args: string[],
+  opts?: {
+    valueOptions?: string[];
+    stopAtDoubleDash?: boolean;
+  }
+) => {
+  let valueOptions = new Set(opts?.valueOptions ?? []);
+
+  for (let i = 0; i < args.length; i++) {
+    let arg = args[i];
+
+    if (opts?.stopAtDoubleDash && arg == '--') {
+      return args.slice(i + 1);
+    }
+
+    if (arg.startsWith('-')) {
+      if (optionTakesValue(arg, valueOptions)) i++;
+      continue;
+    }
+
+    return args.slice(i + 1);
+  }
+};
+
+let NODE_RUNNER_VALUE_OPTIONS = [
+  '--cache',
+  '--cache-dir',
+  '--cwd',
+  '--directory',
+  '--env-file',
+  '--loader',
+  '--prefix',
+  '--require',
+  '--title',
+  '-C',
+  '-e',
+  '-r'
+];
+
+let PACKAGE_RUNNER_VALUE_OPTIONS = [
+  ...NODE_RUNNER_VALUE_OPTIONS,
+  '--from',
+  '--package',
+  '--registry',
+  '--tag',
+  '--with',
+  '--with-editable',
+  '--with-requirements',
+  '--python',
+  '--index-url',
+  '--extra-index-url',
+  '--find-links',
+  '--resolution',
+  '--prerelease',
+  '--fork-strategy',
+  '--link-mode',
+  '--exclude-newer',
+  '--refresh-package',
+  '-p'
+];
+
+let UV_RUN_VALUE_OPTIONS = [
+  ...PACKAGE_RUNNER_VALUE_OPTIONS,
+  '--active',
+  '--directory',
+  '--env-file',
+  '--extra',
+  '--group',
+  '--isolated',
+  '--module',
+  '--project',
+  '--script',
+  '--with-requirements',
+  '-m'
+];
+
 let argParsers = [
   {
     commands: [
       pathCommand('uvx'),
       pathCommand('npx'),
+      pathCommand('bunx')
+    ],
+    parser: (args: string[]) => {
+      return argsAfterEntrypoint(args, {
+        valueOptions: PACKAGE_RUNNER_VALUE_OPTIONS,
+        stopAtDoubleDash: true
+      });
+    }
+  },
+
+  {
+    commands: [
       pathCommand('python'),
       pathCommand('python3'),
       pathCommand('node'),
       pathCommand('ts-node'),
-      pathCommand('bun'),
-      pathCommand('bunx')
+      pathCommand('bun')
     ],
     parser: (args: string[]) => {
-      for (let i = 0; i < args.length; i++) {
-        let arg = args[i];
-        if (arg.startsWith('-')) continue;
-
-        return args.slice(i + 1);
-      }
+      return argsAfterEntrypoint(args, {
+        valueOptions: NODE_RUNNER_VALUE_OPTIONS,
+        stopAtDoubleDash: true
+      });
     }
   },
 
@@ -75,7 +170,10 @@ let argParsers = [
       for (let i = 0; i < args.length; i++) {
         let arg = args[i];
         if (arg == 'run') {
-          return args.slice(i + 1);
+          return argsAfterEntrypoint(args.slice(i + 1), {
+            valueOptions: UV_RUN_VALUE_OPTIONS,
+            stopAtDoubleDash: true
+          });
         }
       }
     }


### PR DESCRIPTION
## Summary
- skip known runner option values before detecting the MCP server entrypoint for npx, bunx, uvx, node/python/bun, and uv run configs
- avoid treating non-placeholder uppercase literals like OWNER/REPO as configurable keys
- add focused Bun regression coverage for uvx, npx, and uv run MCP server configs

## Why
Metorial imports MCP server configuration from README mcpServers blocks. The previous parser skipped flags but not the values for runner-level options like --from or --package, so package/source values could be misread as the server entrypoint and leak into generated CLI config. That can produce noisy or incorrect manifests for catalog entries.

## Tests
- npx --yes bun test packages/server-config/src/parseMCPServers.test.ts
- node_modules/.bin/tsc --noEmit -p packages/server-config/tsconfig.json